### PR TITLE
Use `getenv` instead of `$_ENV`

### DIFF
--- a/run.php
+++ b/run.php
@@ -6,7 +6,7 @@ spl_autoload_register(function (string $className) {
 
 $httpReader = new HTTPReader();
 
-$offerCollection = $httpReader->read(file_get_contents($_ENV['OFFERS_ENDPOINT']));
+$offerCollection = $httpReader->read(file_get_contents(getenv('OFFERS_ENDPOINT')));
 $productIterator = $offerCollection->getIterator();
 
 $subcommand2FilterMapping = [


### PR DESCRIPTION
It's better to use `getenv('OFFERS_ENDPOINT')` instead of `$_ENV['OFFERS_ENDPOINT']` as ENV is not recommended on production servers and is usually disabled by default.